### PR TITLE
Make file_exists in upload.php work

### DIFF
--- a/public/upload.php
+++ b/public/upload.php
@@ -27,7 +27,7 @@ function generateNewHash($type)
         $str .= substr($an, rand(0, strlen($an) - 1), 1);
     }
 
-    if ( ! file_exists(__DIR__ . "/images/$type/$str")) {
+    if ( ! file_exists(__DIR__ . "/images/$type/$str.$type")) {
         return $str;
     } else {
         return generateNewHash($type);


### PR DESCRIPTION
`file_exists` needs an extension to work, it won't try without.
This means that the current checking does absolutely nothing, and the names can conflict.

This change _should_ fix that, or at least did in my basic testing.