### PR TITLE
Fix for XSS and path travel

### DIFF
--- a/public/protected/templates/viewer.phtml
+++ b/public/protected/templates/viewer.phtml
@@ -13,7 +13,7 @@
         <meta name="twitter:site" content="<?php echo TWITTER_HANDLE; ?>" />
         <meta name="twitter:title" content="<?php echo $file . '.' . $type; ?>" />
         <meta name="twitter:image" content="<?php echo $protocol; ?>://<?php echo $_SERVER['SERVER_NAME'] . $imgurl; ?>" />
-        <meta name="twitter:url" content="<?php echo $protocol; ?>://<?php echo $_SERVER['SERVER_NAME'] . $_SERVER['REQUEST_URI']; ?>" />
+        <meta name="twitter:url" content="<?php echo $protocol; ?>://<?php echo $_SERVER['SERVER_NAME'] . htmlspecialchars($_SERVER['REQUEST_URI']); ?>" />
 <?php } ?>
     </head>
 

--- a/public/viewer.php
+++ b/public/viewer.php
@@ -21,7 +21,7 @@ $file = $_GET['file'];
 
 $filelocation = __DIR__ . "/images/$type/$file.$type";
 
-if ( ! file_exists($filelocation)) {
+if ( ! file_exists(realpath($filelocation)) || ! array_key_exists($type, $types) ) {
     header('HTTP/1.0 404 Not Found');
     include_once __DIR__ . '/protected/templates/error.phtml';
     die();


### PR DESCRIPTION
REQUEST_URI is not parsed by PHP - only by new browsers.
Can be used for XSS with curl or for example file get contents.
`[url]?x="><h1>Hi</h1>`

Using path travel and viewer.php you can get files like the config file.
`[url]/viewer.php?type=png&file=../png/../png/../png/jAfQv`