### PR TITLE
Fixes on things

### DIFF
--- a/public/protected/templates/error.phtml
+++ b/public/protected/templates/error.phtml
@@ -1,9 +1,10 @@
+<?php $stylesheetDir = IMAGESERVE_DIR . "/assets/css/style.css"; ?>
 <!DOCTYPE html>
 <html lang="en">
     <head>
         <meta charset="UTF-8">
         <title><?php echo APP_NAME . " - Error"; ?></title>
-        <link rel="stylesheet" href="/assets/css/style.css">
+        <link rel="stylesheet" href="<?php echo $stylesheetDir; ?>">
     </head>
 
     <body>

--- a/public/protected/templates/index.phtml
+++ b/public/protected/templates/index.phtml
@@ -1,9 +1,10 @@
+<?php $stylesheetDir = IMAGESERVE_DIR . "/assets/css/style.css"; ?>
 <!DOCTYPE html>
 <html lang="en">
     <head>
         <meta charset="UTF-8">
         <title><?php echo APP_NAME . " - Home"; ?></title>
-        <link rel="stylesheet" href="/assets/css/style.css">
+        <link rel="stylesheet" href="<?php echo $stylesheetDir; ?>">
     </head>
 
     <body>

--- a/public/protected/templates/viewer.phtml
+++ b/public/protected/templates/viewer.phtml
@@ -1,13 +1,14 @@
 <?php
     $imgurl = IMAGESERVE_DIR . "/images/$type/$file.$type";
-    $protocol = isset($_SERVER['https']) && $_SERVER['https'] != "off" ? "https" : "http";
+    $protocol = isset($_SERVER['HTTPS']) && $_SERVER['HTTPS'] != "off" ? "https" : "http";
+    $stylesheetDir = IMAGESERVE_DIR . "/assets/css/style.css";
 ?>
 <!DOCTYPE html>
 <html lang="en">
     <head>
         <meta charset="UTF-8">
         <title><?php echo APP_NAME . " - $file.$type"; ?></title>
-        <link rel="stylesheet" href="/assets/css/style.css">
+        <link rel="stylesheet" href="<?php echo $stylesheetDir; ?>">
 <?php if (TWITTER_CARDS) { ?>
         <meta name="twitter:card" content="photo" />
         <meta name="twitter:site" content="<?php echo TWITTER_HANDLE; ?>" />


### PR DESCRIPTION
* Fixed HTTPS detection on `viewer.phtml`.
* Fixed Stylesheet location where it was relying on site root.

One request for the wiki:

If the server has HTTPS redirection (with the `.htaccess` file on the site root), this gets turned off on the imageserve folder. I am suggesting that these lines should be added to the `public/.htaccess` file:

```
# old code above
RewriteEngine On

RewriteCond %{HTTPS} off
RewriteRule ^(.*)$ https://%{HTTP_HOST}%{REQUEST_URI} [L,R=301]

RewriteRule  ^/?$                           viewer.php                      [L]
# old code below
```

Edited: Markdown failure on multi-line code.
Edited again and again: General look and markdown fixes.