### PR TITLE
Docker support + improve url handling

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,6 @@
+public/protected/config/config.php
+*.gif
+*.jpg
+*.jpeg
+*.png
+*.webm

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,16 @@
+FROM php:apache
+
+# Enable mod_rewrite
+RUN a2enmod rewrite
+
+# Use the default production configuration
+RUN cp "$PHP_INI_DIR/php.ini-production" "$PHP_INI_DIR/php.ini"
+
+# Set upload filesize limit
+ENV UPLOAD_LIMIT=64M
+RUN sed -ri -e 's/upload_max_filesize = .*/upload_max_filesize = ${UPLOAD_LIMIT}/' "$PHP_INI_DIR/php.ini"
+
+# Copy project files
+WORKDIR /var/www/html/
+COPY ./public/ .
+COPY ./config-env.php ./protected/config/config.php

--- a/config-env.php
+++ b/config-env.php
@@ -6,7 +6,10 @@ foreach ($types as $type) {
 }
 
 // required
-if (getenv('PASSKEY') === false) die('PASSKEY must not be unset!');
+if (getenv('PASSKEY') === false) {
+    http_response_code(500);
+    die('PASSKEY must not be unset!');
+}
 
 // defaults
 $IMAGESERVE_DIR = getenv('IMAGESERVE_DIR') !== false ? getenv('IMAGESERVE_DIR') : '';

--- a/config-env.php
+++ b/config-env.php
@@ -1,0 +1,23 @@
+<?php
+// setup folders
+$types = array('png', 'jpeg', 'gif', 'webm');
+foreach ($types as $type) {
+    if (!is_dir('images/' . $type)) mkdir('images/' . $type);
+}
+
+// required
+if (getenv('PASSKEY') === false) die('PASSKEY must not be unset!');
+
+// defaults
+$IMAGESERVE_DIR = getenv('IMAGESERVE_DIR') !== false ? getenv('IMAGESERVE_DIR') : '';
+$TWITTER_HANDLE = getenv('TWITTER_HANDLE') !== false ? getenv('TWITTER_HANDLE') : '';
+$APP_NAME = getenv('APP_NAME') !== false ? getenv('APP_NAME') : 'imageserve';
+
+define('PASSKEY', getenv('PASSKEY'));
+define('RAW_IMAGE', getenv('RAW_IMAGE') !== false);
+define('RAW_IMAGE_LINK', getenv('RAW_IMAGE_LINK') !== false);
+define('IMAGE_EXTENSION', getenv('IMAGE_EXTENSION') !== false);
+define('TWITTER_CARDS', getenv('TWITTER_CARDS') !== false);
+define('IMAGESERVE_DIR', $IMAGESERVE_DIR);
+define('TWITTER_HANDLE', $TWITTER_HANDLE);
+define('APP_NAME', $APP_NAME);

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,21 @@
+version: "3.9"
+services:
+  imageserve:
+    build: .
+    image: imageserve
+    container_name: imageserve
+    ports:
+      - "8080:80"
+    volumes:
+      - "/path/to/dir:/var/www/html/images"
+    environment:
+      PASSKEY: 'CHANGE THIS'
+      # UPLOAD_LIMIT: 64M
+      # RAW_IMAGE: 1
+      # RAW_IMAGE_LINK: 1
+      # IMAGE_EXTENSION: 1
+      # TWITTER_CARDS: 1
+      # IMAGESERVE_DIR: '/imageserve'
+      # TWITTER_HANDLE: '@someone'
+      # APP_NAME: 'application name'
+    restart: unless-stopped

--- a/public/.htaccess
+++ b/public/.htaccess
@@ -14,9 +14,12 @@ RewriteRule  ^/?$                           viewer.php                      [L]
 
 RewriteRule  ^g/([^/\.]+)(.gif)?/?$         viewer.php?type=gif&file=$1     [L]
 RewriteRule  ^j/([^/\.]+)(.jpg|.jpeg)?/?$   viewer.php?type=jpeg&file=$1    [L]
+RewriteRule  ^p/([^/\.]+)(.png)?/?$         viewer.php?type=png&file=$1     [L]
 RewriteRule  ^w/([^/\.]+)(.webm)?/?$        viewer.php?type=webm&file=$1    [L]
 
-RewriteRule  ^([^/\.]+).gif/?$              viewer.php?type=gif&file=$1     [L]
+RewriteRule  ^([^/\.]+)(.gif)/?$            viewer.php?type=gif&file=$1     [L]
 RewriteRule  ^([^/\.]+)(.jpg|.jpeg)/?$      viewer.php?type=jpeg&file=$1    [L]
+RewriteRule  ^([^/\.]+)(.png)/?$            viewer.php?type=png&file=$1     [L]
+RewriteRule  ^([^/\.]+)(.webm)/?$           viewer.php?type=webm&file=$1    [L]
 
-RewriteRule  ^([^/\.]+)(.png)?/?$           viewer.php?type=png&file=$1     [L]
+RewriteRule  ^([^/\.]+)/?$                  viewer.php?type=&file=$1        [L]

--- a/public/upload.php
+++ b/public/upload.php
@@ -5,14 +5,17 @@ require_once __DIR__ . '/protected/config/config.php';
 $allowedTypes = array('image/png', 'image/jpeg', 'image/gif', 'video/webm');
 
 if ( ! isset($_POST['password']) || $_POST['password'] !== PASSKEY) {
+    http_response_code(401);
     die('error,e-401');
 }
 
 if ( ! (filesize($_FILES['image']['tmp_name']) > 0 && in_array($_FILES['image']['type'], $allowedTypes))) {
+    http_response_code(415);
     die('error,e-415');
 }
 
 if ($_FILES['image']['error'] > 0) {
+    http_response_code(500);
     die('error,e-500');
 }
 
@@ -48,5 +51,6 @@ function saveImage($mimeType, $tempName)
         die('success,' . (RAW_IMAGE_LINK ? $dir . "$type/$hash.$type" : ($type == 'png' ? '' : substr($type, 0, 1) . '/') . "$hash" . (IMAGE_EXTENSION ? ".$type" : '')));
     }
 
+    http_response_code(500);
     die('error,e-500x');
 }

--- a/public/viewer.php
+++ b/public/viewer.php
@@ -19,10 +19,20 @@ if ($index) {
 $type = $_GET['type'];
 $file = $_GET['file'];
 
+if ($type == '') {
+    // try to guess the type
+    foreach ($types as $i => $v) {
+        if (file_exists(__DIR__ . "/images/$i/$file.$i")) {
+            $type = $i;
+            break;
+        }
+    }
+}
+
 $filelocation = __DIR__ . "/images/$type/$file.$type";
 
-if ( ! file_exists(realpath($filelocation)) || ! array_key_exists($type, $types)) {
-    header('HTTP/1.0 404 Not Found');
+if ( ! array_key_exists($type, $types) || ! file_exists($filelocation)) {
+    http_response_code(404);
     include_once __DIR__ . '/protected/templates/error.phtml';
     die();
 }


### PR DESCRIPTION
Since many people (including me) were struggling with setting this up correctly, I decided to create a docker configuration so it can be deployed more easily. Bare metal deployment is still 100% possible like before, for those who need/prefer that.

When the image is built, the normal `config.php` is replaced with another one that uses environment variables. This way, you can configure everything at run time. Simply uncomment the variables you need. Flags like `RAW_IMAGE_LINK` will become true if the variable is set to anything (actual boolean values are not supported).  
I also added a variable to easily change the `upload_max_filesize` in php.ini (default is 64M now instead of 2M).

The images directory is a bind mounted external folder, and the exposed port for http will be 8080 by default. You can easily change this as you want, but the better alternative would be to disable the port completely and put the container behind a reverse proxy with https instead (system nginx, another container, ...).

To deploy, all you need to do is clone, edit `docker-compose.yml` and execute this:
```bash
docker-compose build
docker-compose up -d
```
... or `docker-compose up -d --build` for short. No need to touch `config.php` or `php.ini` to get get it running.

<hr/>

Along the way I noticed that the way urls are handled in `.htaccess` and `upload.php` is very hit-and-miss / only works for a very specific configuration and breaks in unexpected ways otherwise. So I made that more consistent and "robust" overall:
 - return the actual http code on error - ShareX can't detect errors otherwise
 - make the file hash unique across all file types
 - if the file extension is omitted in the url, "guess" the type by looking in every folder
 - the regular url path that `upload.php` returns will now be just the hash (+ extension), so the full url would be something like `<hostname>/s7nHl`, consistently for all file types
 - `RAW_IMAGE_LINK` was completely broken (it returned the absolute path on the server's filesystem), works as intended now
 - all file types can be accessed like `/s7nHl`, `/s7nHl.png`, `/p/s7nHl`, `/p/s7nHl.png` or direct link, so these changes should be 100% backwards compatible (for existing shared links)

<details> 
  <summary>Also I suggest using this custom uploader config in ShareX (this way all kinds of url the server returns should work fine)</summary>
<pre><code>{
  "Version": "13.5.0",
  "Name": "imageserve",
  "DestinationType": "ImageUploader, FileUploader",
  "RequestMethod": "POST",
  "RequestURL": "[hostname]/upload.php",
  "Body": "MultipartFormData",
  "Arguments": {
    "password": "[your password]"
  },
  "FileFormName": "image",
  "RegexList": [
    "success,(.*)$"
  ],
  "URL": "[hostname]/$regex:1|1$"
}</code></pre>
</details>